### PR TITLE
bugfix: Discover sections correctly in org-files.

### DIFF
--- a/languages/org/outline.scm
+++ b/languages/org/outline.scm
@@ -1,3 +1,8 @@
-(headline (stars) @name.stars (#match? @name.stars "^(\\*{3})*\\*$") (item)) @name @item
-(headline (stars) @name.stars (#match? @name.stars "^(\\*{3})*\\*\\*$") (item)) @name @item
-(headline (stars) @name.stars (#match? @name.stars "^(\\*{3})*\\*\\*\\*$") (item)) @name @item
+(section
+  (headline (stars) @context (#match? @context "^(\\*{3})*\\*$") (item) @name)) @item
+
+(section
+  (headline (stars) @context (#match? @context "^(\\*{3})*\\*\\*$") (item) @name)) @item
+
+(section
+  (headline (stars) @context (#match? @context "^(\\*{3})*\\*\\*\\*$") (item) @name)) @item


### PR DESCRIPTION
Currently sections are only for one line below the heading registered, and subsections are not registered to be subsection of a section. This would fix that.